### PR TITLE
Update description of HTTP/2 server push example

### DIFF
--- a/examples/http-2.0-server-push/http-2.0-server-push.description
+++ b/examples/http-2.0-server-push/http-2.0-server-push.description
@@ -1,1 +1,1 @@
-// This example shows how we can send and receive HTTP/2 Server Push messages in Ballerina HTTP Connector.
+// This example shows how we can send and receive HTTP/2 Server Push messages in Ballerina HTTP Library.


### PR DESCRIPTION
## Purpose
Update description of HTTP/2 server push example by replacing 'connector' word. 

