### PR TITLE
Update identifier-literals.bal

### DIFF
--- a/examples/identifier-literals/identifier-literals.bal
+++ b/examples/identifier-literals/identifier-literals.bal
@@ -1,23 +1,23 @@
 import ballerina/io;
 
 function main (string[] args) {
-    //The vertical bar (|) character is used to demarcate the identifier name.
+    //The `^` character is used to demarcate the identifier name.
     //This is similar to string literals (using double quote characters to demarcate).
     string ^"first name" = "John";
     string ^"last name" = "Gosling";
 
-    //Invoking a function with identifier literal as a parameter.
+    //Invoke a function with the identifier literal as a parameter.
     string name = ^"combine names"(^"first name", ^"last name");
     io:println(name);
 }
 
-@Description {value:"Sample function defined with function name and input parameter using identifier literals."}
+@Description {value:"Define the sample function with a function name and input parameter(s) using identifier literals."}
 function ^"combine names" (string ^"first name",
                           string ^"last name") returns (string) {
     return ^"first name" + " " + ^"last name";
 }
 
-@Description {value:"Struct defined using identifier literals."}
+@Description {value:"Define a struct using identifier literals."}
 type ^"person record" {
     string ^"first name";
     string ^"last name";


### PR DESCRIPTION
## Purpose
The description stated that the " | "character is used to demarcate the identifier name. Changed this to "^" and did some minor review edits. 