### PR TITLE
Added missing comment sign in the description

### DIFF
--- a/examples/xml-attributes/xml-attributes.description
+++ b/examples/xml-attributes/xml-attributes.description
@@ -1,4 +1,4 @@
 // XML elements may have any number of attributes and any number
 // of namespace declarations that apply for that element. 
-/ In Ballerina, both of these types are treated the same. 
+// In Ballerina, both of these types are treated the same. 
 // Attributes are accessed from an XML sequence using the `@` postfix operator.


### PR DESCRIPTION
## Purpose
> Go script which is used to generate the BBE files fails due to the invalid comment character used in the description file. 