### PR TITLE
Fix syntax issues in http-2.0-server-push.bal

### DIFF
--- a/examples/http-2.0-server-push/http-2.0-server-push.bal
+++ b/examples/http-2.0-server-push/http-2.0-server-push.bal
@@ -79,7 +79,7 @@ endpoint http:Client clientEP {
     httpVersion:"2.0"
 };
 
-function main (string[] args) {
+function main (string... args) {
 
     http:Request serviceReq = new;
     http:HttpFuture httpFuture = new;

--- a/examples/http-2.0-server-push/http-2.0-server-push.bal
+++ b/examples/http-2.0-server-push/http-2.0-server-push.bal
@@ -142,7 +142,7 @@ function main (string[] args) {
     var responsePayload = res.getJsonPayload();
     match responsePayload {
         json resultantJsonPayload => {
-            io:println("Response : " + (resultantJsonPayload.toString() but {() => ""}));
+            io:println("Response : " + resultantJsonPayload.toString());
         }
         http:PayloadError err => {
             io:println("Expected response not received");
@@ -166,7 +166,7 @@ function main (string[] args) {
         var promisedPayload = promisedResponse.getJsonPayload();
         match promisedPayload {
             json promisedJsonPayload => {
-                io:println("Promised resource : " + (promisedJsonPayload.toString() but {() => ""}));
+                io:println("Promised resource : " + promisedJsonPayload.toString());
             }
             http:PayloadError err => {
                 io:println("Promised response not received");


### PR DESCRIPTION
## Purpose
Due to an API change in json toString() http-2.0-server-push.bal doesn't compile anymore, need to fix that.

## Goals
Fix syntax issues in http-2.0-server-push.bal 