### PR TITLE
Remove file-api related example

### DIFF
--- a/examples.txt
+++ b/examples.txt
@@ -55,7 +55,6 @@ Transform JSON
 Strings
 Blob Type
 Date Time
-File API
 Throw
 Try/Catch/Finally
 Base Path and Path


### PR DESCRIPTION
## Purpose
Remove file-api example from the generated list. File api move to internal usage.