### PR TITLE
Fix testerina test bal files inconsistencies

### DIFF
--- a/examples/testerina-before-and-after-suite/testerina_before_and_after_suite.out
+++ b/examples/testerina-before-and-after-suite/testerina_before_and_after_suite.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test testerina_before_after_suite.bal
+$ ballerina test testerina_before_and_after_suite.bal
 ---------------------------------------------------------------------------
     T E S T S
 ---------------------------------------------------------------------------

--- a/examples/testerina-before-and-after-test/testerina_before_and_after_test.out
+++ b/examples/testerina-before-and-after-test/testerina_before_and_after_test.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test testerina_before_after.bal
+$ ballerina test testerina_before_and_after_test.bal
 ---------------------------------------------------------------------------
     T E S T S
 ---------------------------------------------------------------------------

--- a/examples/testerina-before-each-test/testerina_before_each_test.out
+++ b/examples/testerina-before-each-test/testerina_before_each_test.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test testerina_before_each.bal
+$ ballerina test testerina_before_each_test.bal
     T E S T S
 ---------------------------------------------------------------------------
 ---------------------------------------------------------------------------

--- a/examples/testerina-data-driven-tests/testerina_data_driven_tests.out
+++ b/examples/testerina-data-driven-tests/testerina_data_driven_tests.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test testerina_data_provider.bal
+$ ballerina test testerina_data_driven_tests.bal
 ---------------------------------------------------------------------------
     T E S T S
 ---------------------------------------------------------------------------

--- a/examples/testerina-group-tests/testerina_group_tests.out
+++ b/examples/testerina-group-tests/testerina_group_tests.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test testerina_groups.bal --groups g1,g2
+$ ballerina test testerina_group_tests.bal --groups g1,g2
 ---------------------------------------------------------------------------
     T E S T S
 ---------------------------------------------------------------------------
@@ -25,7 +25,7 @@ Summary:
 ---------------------------------------------------------------------------
 
 
-$ ballerina test testerina_groups.bal --groups g1
+$ ballerina test testerina_group_tests.bal --groups g1
 ---------------------------------------------------------------------------
     T E S T S
 ---------------------------------------------------------------------------
@@ -48,28 +48,7 @@ Summary:
 ................................................................... SUCCESS
 ---------------------------------------------------------------------------
 
-$ ballerina test testerina_groups.bal --groups default
----------------------------------------------------------------------------
-    T E S T S
----------------------------------------------------------------------------
----------------------------------------------------------------------------
-Running Tests of Package: .
----------------------------------------------------------------------------
-I'm the ungrouped test.
-
-Tests run: 1, Passed: 1, Failures: 0, Skipped: 0 - in TestSuite
-
-
----------------------------------------------------------------------------
-Results:
-
-Tests run: 1, Passed: 1, Failures: 0, Skipped: 0
----------------------------------------------------------------------------
-Summary:
-................................................................... SUCCESS
----------------------------------------------------------------------------
-
-$ ballerina test testerina_groups.bal --exclude-groups g2
+$ ballerina test testerina_group_tests.bal --disable-groups g2
 
 ---------------------------------------------------------------------------
     T E S T S

--- a/examples/testerina-guarantee-test-execution-order/testerina_guarantee_test_execution_order.out
+++ b/examples/testerina-guarantee-test-execution-order/testerina_guarantee_test_execution_order.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test testerina_depends_on.bal
+$ ballerina test testerina_guarantee_test_execution_order.bal
 ---------------------------------------------------------------------------
     T E S T S
 ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix testerina test bal files inconsistencies. Use correct test bal file names in the output files. Remove invalid output content.