### PR TITLE
Fix #843 - Use the assigned float name for println

### DIFF
--- a/examples/packages/packages.bal
+++ b/examples/packages/packages.bal
@@ -13,5 +13,5 @@ function main(string... args) {
     float piValue = math:PI;
 
     // Use the explicit alias `console` to invoke a function defined in the `ballerina/io` package.
-    console:println(math:PI);
+    console:println(piValue);
 }


### PR DESCRIPTION
## Purpose
> Fix #843 - Use the assigned float name for println in package example