### PR TITLE
Improve sample with explicit union type return

### DIFF
--- a/examples/try-catch-finally/try_catch_finally.bal
+++ b/examples/try-catch-finally/try_catch_finally.bal
@@ -8,7 +8,7 @@ function main(string... args) {
     try {
         io:println("Start dividing numbers");
         // An error is thrown when the `divideNumbers` function is executed.
-        result = divideNumbers(1, 0);
+        result = check divideNumbers(1, 0);
         // When an error is thrown, the error type is matched to the clause defined in the `catch` block and the
         // respective `catch` block is called. The `error` type `catch` clause is structurally equivalent to any `error` type
         // that is thrown and it can be used to catch all errors.
@@ -19,6 +19,10 @@ function main(string... args) {
     }
 }
 
-function divideNumbers(int a, int b) returns int {
+function divideNumbers(int a, int b) returns int|error {
+    if (b == 0) {
+        error err = { message: "Division by 0 is not defined" };
+        return err;
+    }
     return a / b;
 }

--- a/examples/try-catch-finally/try_catch_finally.out
+++ b/examples/try-catch-finally/try_catch_finally.out
@@ -2,5 +2,5 @@
 #`.bal` file and run the `ballerina run` command. 
 $ ballerina run try_catch_finally.bal
 Start dividing numbers
-Error occurred: call failed
+Error occurred: Division by 0 is not defined
 Finally block executed


### PR DESCRIPTION
## Purpose
Improve sample to showcase handling union type return in try-catch block, where error is included in a function return. 

## Goals

According to the discussion in ballerina-dev, it is decided to improve the Try/Catch/Finally sample to include a function returning union type, and using 'check' to validate the response, where error is caught in 'catch'.
https://groups.google.com/forum/#!msg/ballerina-dev/uyYZdAyCl9Y/KCJ1sD6aBAAJ
