### PR TITLE
Improve WebSocket examples

### DIFF
--- a/examples/websocket-basic-sample/websocket_basic_sample.bal
+++ b/examples/websocket-basic-sample/websocket_basic_sample.bal
@@ -31,15 +31,11 @@ service<http:WebSocketService> basic bind { port: 9090 } {
                 error e => log:printError("Error sending ping", err = e)
             };
         } else if (text == "closeMe") {
-            caller->close(1001, "You asked me to close the connection") but {
-                error e => log:printError(
-                               "Error occurred when closing the connection",
-                               err = e)
-            };
+            _ = caller->close(1001, "You asked me to close the connection");
         } else {
             caller->pushText("You said: " + text) but {
                 error e => log:printError("Error occurred when sending text",
-                err = e)
+                    err = e)
             };
         }
     }

--- a/examples/websocket-chat-application/websocket_chat_application.bal
+++ b/examples/websocket-chat-application/websocket_chat_application.bal
@@ -47,15 +47,15 @@ service<http:WebSocketService> chatApp {
     // broadcast that the user has joined the chat.
     onOpen(endpoint caller) {
         string msg;
-        msg = string `{{getAttributeStr(caller, NAME)}} with age
-                            {{getAttributeStr(caller, AGE)}} connected to chat`;
+        msg = getAttributeStr(caller, NAME) + " with age"
+            + getAttributeStr(caller, AGE) + " connected to chat";
         broadcast(msg);
         connectionsMap[caller.id] = caller;
     }
 
     // Broadcast the messages sent by a user.
     onText(endpoint caller, string text) {
-        string msg = string `{{getAttributeStr(caller, NAME)}}: {{text}}`;
+        string msg = getAttributeStr(caller, NAME) + ": " + text;
         log:printInfo(msg);
         broadcast(msg);
     }
@@ -63,7 +63,7 @@ service<http:WebSocketService> chatApp {
     // Broadcast that a user has left the chat once a user leaves the chat.
     onClose(endpoint caller, int statusCode, string reason) {
         _ = connectionsMap.remove(caller.id);
-        string msg = string `{{getAttributeStr(caller, NAME)}} left the chat`;
+        string msg = getAttributeStr(caller, NAME) + "left the chat";
         broadcast(msg);
     }
 }


### PR DESCRIPTION
## Purpose
- Remove logging of error for close scenario--otherwise an error is printed whenever a close frame is not received because it is not supported by browsers.
- Improve strings in WebSocket chat example