### PR TITLE
Fix option ordering with Ballerina cmds

### DIFF
--- a/examples/counter-metrics/counter_metrics.server.out
+++ b/examples/counter-metrics/counter_metrics.server.out
@@ -1,6 +1,6 @@
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command with `--observe` param.
-$ ballerina run counter-metrics.bal --observe
+$ ballerina run --observe counter-metrics.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
 ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797

--- a/examples/counter-metrics/counter_metrics.server.out
+++ b/examples/counter-metrics/counter_metrics.server.out
@@ -1,6 +1,6 @@
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command with `--observe` param.
-$ ballerina run --observe counter-metrics.bal
+$ ballerina run --observe counter_metrics.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
 ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797

--- a/examples/gauge-metrics/gauge_metric.server.out
+++ b/examples/gauge-metrics/gauge_metric.server.out
@@ -1,6 +1,6 @@
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command with `--observe` param.
-$ ballerina run --observe counter-metrics.bal
+$ ballerina run --observe gauge_metrics.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
 ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797

--- a/examples/gauge-metrics/gauge_metric.server.out
+++ b/examples/gauge-metrics/gauge_metric.server.out
@@ -1,6 +1,6 @@
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command with `--observe` param.
-$ ballerina run counter-metrics.bal --observe
+$ ballerina run --observe counter-metrics.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
 ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797

--- a/examples/http-access-logs/http_access_logs.server.out
+++ b/examples/http-access-logs/http_access_logs.server.out
@@ -1,14 +1,14 @@
 # At the command line, navigate to the directory that contains the
 # `.bal` file and do one of the following depending on whether you want the logs to be logged on the console, or in a file.
 # Run the service by setting `-e b7a.http.accesslog.console=true` to log to console.
-$ ballerina run http_access_logs.bal -e b7a.http.accesslog.console=true
+$ ballerina run -e b7a.http.accesslog.console=true http_access_logs.bal
 ballerina: HTTP access log enabled
 ballerina: initiating service(s) in 'http_access_logs.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9095
 127.0.0.1 - - [05/Mar/2018:10:16:38 +0530] "GET /hello HTTP/1.1" 200 10 "-" "curl/7.55.1"
 
 # Or, run the service by setting `-e b7a.http.accesslog.path=path/to/file.txt` to log to the specified file.
-$ ballerina run http_access_logs.bal -e b7a.http.accesslog.path=path/to/file.txt
+$ ballerina run -e b7a.http.accesslog.path=path/to/file.txt http_access_logs.bal
 ballerina: HTTP access log enabled
 ballerina: initiating service(s) in 'http_access_logs.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9095

--- a/examples/http-trace-logs/http_trace_logs.server.out
+++ b/examples/http-trace-logs/http_trace_logs.server.out
@@ -2,7 +2,7 @@
 # To enable trace logs, the log level has to be set to `TRACE` using the runtime argument: <br> '-e b7a.http.tracelog.console=true'. <br>
 # At the command line, navigate to the directory that contains the 
 # `.bal` file and run the `ballerina run` command with this runtime argument. 
-$ ballerina run http_trace_logs.bal -e b7a.http.tracelog.console=true
+$ ballerina run -e b7a.http.tracelog.console=true http_trace_logs.bal
 ballerina: HTTP trace log enabled
 ballerina: initiating service(s) in 'http_trace_logs.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/log-api/log_api.out
+++ b/examples/log-api/log_api.out
@@ -6,7 +6,7 @@ $ ballerina run log_api.bal
 2018-05-30 11:00:50,886 WARN  [] - warn log
 
 # If the log level is set to `TRACE`, logs of all log levels are logged.
-$ ballerina run log_api.bal -e b7a.log.level=TRACE
+$ ballerina run -e b7a.log.level=TRACE log_api.bal
 2018-05-30 11:01:26,083 DEBUG [] - debug log
 2018-05-30 11:01:26,086 ERROR [] - error log
 2018-05-30 11:01:26,087 ERROR [] - error log with cause : {message:"error occurred", cause:null}

--- a/examples/testerina-group-tests/testerina_group_tests.out
+++ b/examples/testerina-group-tests/testerina_group_tests.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test --groups g1,g2 testerina_group_tests.bal
+$ ballerina test testerina_group_tests.bal --groups g1 --groups g2
 Compiling tests
     testerina_group_tests.bal
 
@@ -19,7 +19,7 @@ I'm in test belonging to g1!
 	  0 skipped
 
 
-$ ballerina test --groups g1 testerina_group_tests.bal
+$ ballerina test testerina_group_tests.bal --groups g1
 Compiling tests
     testerina_group_tests.bal
 
@@ -36,7 +36,7 @@ I'm in test belonging to g1!
 	  0 skipped
 
 
-$ ballerina test --disable-groups g2 testerina_group_tests.bal
+$ ballerina test testerina_group_tests.bal --disable-groups g2
 Compiling tests
     testerina_group_tests.bal
 

--- a/examples/testerina-group-tests/testerina_group_tests.out
+++ b/examples/testerina-group-tests/testerina_group_tests.out
@@ -2,7 +2,7 @@
 #`.bal` file and run the `ballerina test` command.
 #Note that you need to have the ballerina-tools distribution 
 #installed in order to run this command. 
-$ ballerina test testerina_group_tests.bal --groups g1,g2
+$ ballerina test --groups g1,g2 testerina_group_tests.bal
 Compiling tests
     testerina_group_tests.bal
 
@@ -19,7 +19,7 @@ I'm in test belonging to g1!
 	  0 skipped
 
 
-$ ballerina test testerina_group_tests.bal --groups g1
+$ ballerina test --groups g1 testerina_group_tests.bal
 Compiling tests
     testerina_group_tests.bal
 
@@ -36,7 +36,7 @@ I'm in test belonging to g1!
 	  0 skipped
 
 
-$ ballerina test testerina_group_tests.bal --disable-groups g2
+$ ballerina test --disable-groups g2 testerina_group_tests.bal
 Compiling tests
     testerina_group_tests.bal
 

--- a/examples/tracing/tracing.server.out
+++ b/examples/tracing/tracing.server.out
@@ -3,7 +3,7 @@ $ docker run -d -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16
 
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command with `--observe` param.
-$ ballerina run tracer.bal --observe
+$ ballerina run --observe tracer.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
 ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797

--- a/examples/tracing/tracing.server.out
+++ b/examples/tracing/tracing.server.out
@@ -3,7 +3,7 @@ $ docker run -d -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16
 
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command with `--observe` param.
-$ ballerina run --observe tracer.bal
+$ ballerina run --observe tracing.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
 ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797


### PR DESCRIPTION
## Purpose
With PR https://github.com/ballerina-platform/ballerina-lang/pull/9991 option vs param ordering will be enforced for Ballerina commands.

This PR fixes incorrect usage, where options have been specified after the source to run.