### PR TITLE
Remove 'channel' variable name

### DIFF
--- a/examples/byte-io/byte_io.bal
+++ b/examples/byte-io/byte_io.bal
@@ -6,15 +6,15 @@ import ballerina/io;
 function getFileChannel(string filePath,
                         io:Mode permission) returns io:ByteChannel {
     // Here is how the ByteChannel is retrieved from the file.
-    io:ByteChannel channel = io:openFile(filePath, permission);
-    return channel;
+    io:ByteChannel byteChannel = io:openFile(filePath, permission);
+    return byteChannel;
 }
 
 // Reads a specified number of bytes from the given channel.
-function readBytes(io:ByteChannel channel,
+function readBytes(io:ByteChannel byteChannel,
                    int numberOfBytes) returns (byte[], int) {
     // Here is how the bytes are read from the channel.
-    var result = channel.read(numberOfBytes);
+    var result = byteChannel.read(numberOfBytes);
     match result {
         (byte[], int) content => {
             return content;
@@ -26,11 +26,11 @@ function readBytes(io:ByteChannel channel,
 }
 
 // Writes byte content with the given offset to a channel.
-function writeBytes(io:ByteChannel channel,
+function writeBytes(io:ByteChannel byteChannel,
                     byte[] content,
                     int startOffset = 0) returns int {
     // Here is how the bytes are written to the channel.
-    var result = channel.write(content, startOffset);
+    var result = byteChannel.write(content, startOffset);
     match result {
         int numberOfBytesWritten => {
             return numberOfBytesWritten;

--- a/examples/character-io/character_io.bal
+++ b/examples/character-io/character_io.bal
@@ -6,19 +6,19 @@ import ballerina/io;
 function getFileCharacterChannel(string filePath, io:Mode permission,
                                  string encoding) returns io:CharacterChannel {
     // First, get the ByteChannel representation of the file.
-    io:ByteChannel channel = io:openFile(filePath, permission);
+    io:ByteChannel byteChannel = io:openFile(filePath, permission);
     // Then, create an instance of the CharacterChannel from the ByteChannel
     // to read content as text.
-    io:CharacterChannel charChannel = new(channel, encoding);
+    io:CharacterChannel charChannel = new(byteChannel, encoding);
     return charChannel;
 }
 
-// This function reads characters from 'channel',
+// This function reads characters from 'charChannel',
 //which is an instance of CharacterChannel.
-function readCharacters(io:CharacterChannel channel,
+function readCharacters(io:CharacterChannel charChannel,
                         int numberOfChars) returns string {
     //This is how the characters are read.
-    match channel.read(numberOfChars) {
+    match charChannel.read(numberOfChars) {
         string characters => {
             return characters;
         }
@@ -28,11 +28,11 @@ function readCharacters(io:CharacterChannel channel,
     }
 }
 
-// This function wrties characters to 'channel'
-function writeCharacters(io:CharacterChannel channel, string content,
+// This function wrties characters to 'charChannel'
+function writeCharacters(io:CharacterChannel charChannel, string content,
                          int startOffset) {
     //This is how the characters are written.
-    match channel.write(content, startOffset) {
+    match charChannel.write(content, startOffset) {
         int numberOfCharsWritten => {
             io:println(" No of characters written : " + numberOfCharsWritten);
         }

--- a/examples/csv-io/csv_io.bal
+++ b/examples/csv-io/csv_io.bal
@@ -7,9 +7,9 @@ type Employee record {
     float salary,
 };
 
-// This function reads the next record from the channel.
-function readNext(io:CSVChannel channel) returns string[] {
-    match channel.getNext() {
+// This function reads the next record from the csvChannel.
+function readNext(io:CSVChannel csvChannel) returns string[] {
+    match csvChannel.getNext() {
         string[] records => {
             return records;
         }
@@ -24,13 +24,13 @@ function readNext(io:CSVChannel channel) returns string[] {
 }
 
 // This function reads records one by one and prints the records.
-function process(io:CSVChannel channel) {
+function process(io:CSVChannel csvChannel) {
     try {
         // Read all the records from the provided file
         // until there are no more records.
-        while (channel.hasNext()) {
+        while (csvChannel.hasNext()) {
             // Read the records.
-            string[] records = readNext(channel);
+            string[] records = readNext(csvChannel);
             // Print the records.
             io:println(records);
         }

--- a/examples/data-io/data_io.bal
+++ b/examples/data-io/data_io.bal
@@ -9,8 +9,8 @@ public type Person record {
 };
 
 //Serialize record into binary
-function serialize(Person p, io:ByteChannel channel) {
-    io:DataChannel dc = new io:DataChannel(channel);
+function serialize(Person p, io:ByteChannel byteChannel) {
+    io:DataChannel dc = new io:DataChannel(byteChannel);
     var length = lengthof p.name.toByteArray("UTF-8");
     var lengthResult = dc.writeInt32(length);
     var nameResult = dc.writeString(p.name, "UTF-8");
@@ -21,11 +21,11 @@ function serialize(Person p, io:ByteChannel channel) {
 }
 
 //Deserialize record into binary
-function deserialize(io:ByteChannel channel) returns Person {
+function deserialize(io:ByteChannel byteChannel) returns Person {
     Person person;
     int nameLength;
     string nameValue;
-    io:DataChannel dc = new io:DataChannel(channel);
+    io:DataChannel dc = new io:DataChannel(byteChannel);
     //Read 32 bit singed integer
     match dc.readInt32() {
         int namel => nameLength = namel;

--- a/examples/http-streaming/http_streaming.bal
+++ b/examples/http-streaming/http_streaming.bal
@@ -98,16 +98,16 @@ service<http:Service> HTTPStreamingService bind { port: 9090 } {
 function getFileChannel(string filePath, io:Mode permission)
     returns (io:ByteChannel) {
     // Here is how the ByteChannel is retrieved from the file.
-    io:ByteChannel channel = io:openFile(filePath, permission);
-    return channel;
+    io:ByteChannel byteChannel = io:openFile(filePath, permission);
+    return byteChannel;
 }
 
 // This function reads a specified number of bytes from the given channel.
-function readBytes(io:ByteChannel channel, int numberOfBytes)
+function readBytes(io:ByteChannel byteChannel, int numberOfBytes)
     returns (byte[], int) {
 
     // Here is how the bytes are read from the channel.
-    var result = channel.read(numberOfBytes);
+    var result = byteChannel.read(numberOfBytes);
     match result {
         (byte[], int) content => {
             return content;
@@ -119,11 +119,11 @@ function readBytes(io:ByteChannel channel, int numberOfBytes)
 }
 
 // This function writes a byte content with the given offset to a channel.
-function writeBytes(io:ByteChannel channel, byte[] content, int startOffset = 0)
+function writeBytes(io:ByteChannel byteChannel, byte[] content, int startOffset = 0)
     returns (int) {
 
     // Here is how the bytes are written to the channel.
-    var result = channel.write(content, startOffset);
+    var result = byteChannel.write(content, startOffset);
     match result {
         int numberOfBytesWritten => {
             return numberOfBytesWritten;

--- a/examples/record-io/record_io.bal
+++ b/examples/record-io/record_io.bal
@@ -9,10 +9,10 @@ import ballerina/log;
 function getFileRecordChannel(string filePath, io:Mode permission,
                               string encoding, string rs,
                               string fs) returns (io:DelimitedTextRecordChannel) {
-    io:ByteChannel channel = io:openFile(filePath, permission);
+    io:ByteChannel byteChannel = io:openFile(filePath, permission);
     // Create a `character channel`
     // from the `byte channel` to read content as text.
-    io:CharacterChannel characterChannel = new(channel, encoding);
+    io:CharacterChannel characterChannel = new(byteChannel, encoding);
     // Convert the `character channel` to a `record channel`
     //to read the content as records.
     io:DelimitedTextRecordChannel delimitedRecordChannel = new(characterChannel,

--- a/examples/response-with-multiparts/response_with_multiparts.bal
+++ b/examples/response-with-multiparts/response_with_multiparts.bal
@@ -179,16 +179,16 @@ function handleContent(mime:Entity bodyPart) {
 function getFileChannel(string filePath, io:Mode permission)
     returns (io:ByteChannel) {
     // Here is how the ByteChannel is retrieved from the file.
-    io:ByteChannel channel = io:openFile(filePath, permission);
-    return channel;
+    io:ByteChannel byteChannel = io:openFile(filePath, permission);
+    return byteChannel;
 }
 
 // This function reads a specified number of bytes from the given channel.
-function readBytes(io:ByteChannel channel, int numberOfBytes)
+function readBytes(io:ByteChannel byteChannel, int numberOfBytes)
     returns (byte[], int) {
 
     // Here is how the bytes are read from the channel.
-    var result = channel.read(numberOfBytes);
+    var result = byteChannel.read(numberOfBytes);
     match result {
         (byte[], int) content => {
             return content;
@@ -200,11 +200,11 @@ function readBytes(io:ByteChannel channel, int numberOfBytes)
 }
 
 // This function writes a byte content with the given offset to a channel.
-function writeBytes(io:ByteChannel channel, byte[] content, int startOffset = 0)
+function writeBytes(io:ByteChannel byteChannel, byte[] content, int startOffset = 0)
     returns (int) {
 
     // Here is how the bytes are written to the channel.
-    var result = channel.write(content, startOffset);
+    var result = byteChannel.write(content, startOffset);
     match result {
         int numberOfBytesWritten => {
             return numberOfBytesWritten;

--- a/examples/workers/tests/worker_test.bal
+++ b/examples/workers/tests/worker_test.bal
@@ -24,6 +24,13 @@ public function mockPrint(any... s) {
 function testFunc() {
     // Invoke the main function. 
     main();
-    test:assertEquals(outputs[0], "sum of first 10000000 positive numbers = 50000005000000");
-    test:assertEquals(outputs[1], "sum of squares of first 10000000 positive numbers = 1291990006563070912");
+    boolean assert = false;
+    if((outputs[0] == "sum of first 10000000 positive numbers = 50000005000000") &&
+                    (outputs[1] == "sum of squares of first 10000000 positive numbers = 1291990006563070912")) {
+        assert = true;
+    } else if ((outputs[1] == "sum of first 10000000 positive numbers = 50000005000000") &&
+                   (outputs[0] == "sum of squares of first 10000000 positive numbers = 1291990006563070912")) {
+        assert = true;
+    }
+    test:assertTrue(assert);
 }


### PR DESCRIPTION
## Purpose
> With the introduction of "channel" type the word 'channel' is a reserved keyword. Hence those variable names should be changed.

> Existing variable names and the field name in socket is cha changed. Every channel is a one of byte, csv, character type channel. Hence each variable is changed according to it's type.

> This PR should be merged along with the PR https://github.com/ballerina-platform/ballerina-lang/pull/10334.
