### PR TITLE
Update "Initiating service(s) ..." CLI message

### DIFF
--- a/examples/base-path-and-path/base_path_and_path.server.out
+++ b/examples/base-path-and-path/base_path_and_path.server.out
@@ -1,5 +1,5 @@
 #At the command line, navigate to the directory that contains the 
 #`.bal` file and run the `ballerina run` command to start the server.  
 $ ballerina run base_path_and_path.bal
-ballerina: initiating service(s) in '.../base_path_and_path.bal'
+Initiating service(s) in '.../base_path_and_path.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/config-api/config_api.out
+++ b/examples/config-api/config_api.out
@@ -32,7 +32,7 @@ ballerina: enter secret for config value decryption:
 $ ballerina run --config path/to/conf/file/custom-config-file-name.conf config_api.bal
 ballerina: enter secret for config value decryption:
 
-ballerina: initiating service(s) in `config_api.bal`
+Initiating service(s) in `config_api.bal`
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:8085
 
 # The same configurations given via a configuration file can also be given via CLI parameters. <br>
@@ -40,5 +40,5 @@ ballerina: started HTTPS/WSS endpoint 0.0.0.0:8085
 $ ballerina run config_api.bal -e hello.http.port=8085 -e hello.keystore.password=@encrypted:{jFMAXsuMSiOCaxuDLuQjVXzMzZxQrten0652/j93Amw=}
 ballerina: enter secret for config value decryption:
 
-ballerina: initiating service(s) in `config_api.bal`
+Initiating service(s) in `config_api.bal`
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:8085

--- a/examples/content-based-routing/content_based_routing.server.out
+++ b/examples/content-based-routing/content_based_routing.server.out
@@ -1,3 +1,3 @@
 $ ballerina run content_based_routing.bal
-ballerina: initiating service(s) in 'content_based_routing.bal'
+Initiating service(s) in 'content_based_routing.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/counter-metrics/counter_metrics.server.out
+++ b/examples/counter-metrics/counter_metrics.server.out
@@ -2,10 +2,10 @@
 # `.bal` file and use the `ballerina run` command with `--observe` param.
 $ ballerina run --observe counter_metrics.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
-ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
+Initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797
 ballerina: started Prometheus HTTP endpoint 0.0.0.0:9797
-ballerina: initiating service(s) in 'counter_metrics.bal'
+Initiating service(s) in 'counter_metrics.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 ------------------------------------------
 Global Counter = 1

--- a/examples/directory-listener/directory_listener.out
+++ b/examples/directory-listener/directory_listener.out
@@ -1,6 +1,6 @@
 # Create a new file called `test1.txt` in the directory called `observed-dir` and modify and delete it.
 $ ballerina run directory_listener.bal
-ballerina: initiating service(s) in 'directory_listener.bal'
+Initiating service(s) in 'directory_listener.bal'
 Create: /home/ballerina/fs-server-connector/observed-dir/test1.txt
 Modify: /home/ballerina/fs-server-connector/observed-dir/test1.txt
 Delete: /home/ballerina/fs-server-connector/observed-dir/test1.txt

--- a/examples/gauge-metrics/gauge_metric.server.out
+++ b/examples/gauge-metrics/gauge_metric.server.out
@@ -2,10 +2,10 @@
 # `.bal` file and use the `ballerina run` command with `--observe` param.
 $ ballerina run --observe gauge_metrics.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
-ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
+Initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797
 ballerina: started Prometheus HTTP endpoint 0.0.0.0:9797
-ballerina: initiating service(s) in 'counter_metrics.bal'
+Initiating service(s) in 'counter_metrics.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 ------------------------------------------
 Gauge - global_gauge Snapshot: [{timeWindow:600000, mean:15.0, max:15.0, min:15.0, stdDev:0.0, percentileValues:[{percentile:0.33, value:15.0}, {percentile:0.5, value:15.0}, {percentile:0.66, value:15.0}, {percentile:0.99, value:15.0}]}]

--- a/examples/header-based-routing/header_based_routing.server.out
+++ b/examples/header-based-routing/header_based_routing.server.out
@@ -1,3 +1,3 @@
 $ ballerina run header_based_routing.bal
-ballerina: initiating service(s) in 'header_based_routing.bal'
+Initiating service(s) in 'header_based_routing.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/hello-world-service/hello_world_service.server.out
+++ b/examples/hello-world-service/hello_world_service.server.out
@@ -1,7 +1,7 @@
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command.
 $ ballerina run hello_world_service.bal
-ballerina: initiating service(s) in 'hello_world_service.bal'
+Initiating service(s) in 'hello_world_service.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090
 
 # To build a compiled program file, use the

--- a/examples/http-1.1-to-2.0-protocol-switch/http_1.1_to_2.0_protocol_switch.server.out
+++ b/examples/http-1.1-to-2.0-protocol-switch/http_1.1_to_2.0_protocol_switch.server.out
@@ -1,6 +1,6 @@
 #At the command line, navigate to the directory that contains the `.bal` file.
 #Run the `ballerina run` command to start the services.
 $ ballerina run http_1.1_to_2.0_protocol_switch.bal
-ballerina: initiating service(s) in 'http_1.1_to_2.0_protocol_switch.bal'
+Initiating service(s) in 'http_1.1_to_2.0_protocol_switch.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:7090
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090

--- a/examples/http-100-continue/http_100_continue.server.out
+++ b/examples/http-100-continue/http_100_continue.server.out
@@ -1,7 +1,7 @@
 #At the command line, navigate to the directory that contains the 
 #`.bal` file and run the `ballerina run` command to start the server. 
 $ ballerina run http_expect_header.bal
-ballerina: initiating service(s) in 'http_100_continue.bal'
+Initiating service(s) in 'http_100_continue.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 2018-04-25 15:18:56,033 INFO  [] - TEST 100 CONTINUE
 

--- a/examples/http-2.0-server-push/http_2.0_service.out
+++ b/examples/http-2.0-server-push/http_2.0_service.out
@@ -1,5 +1,5 @@
 #At the command line, navigate to the directory that contains the `http_2.0_service.bal` file.
 #Run the `ballerina run` command to start the service.
 $ ballerina run http_2.0_service.bal
-ballerina: initiating service(s) in 'http_2.0_service.bal'
+Initiating service(s) in 'http_2.0_service.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:7090

--- a/examples/http-access-logs/http_access_logs.server.out
+++ b/examples/http-access-logs/http_access_logs.server.out
@@ -3,12 +3,12 @@
 # Run the service by setting `-e b7a.http.accesslog.console=true` to log to console.
 $ ballerina run -e b7a.http.accesslog.console=true http_access_logs.bal
 ballerina: HTTP access log enabled
-ballerina: initiating service(s) in 'http_access_logs.bal'
+Initiating service(s) in 'http_access_logs.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9095
 127.0.0.1 - - [05/Mar/2018:10:16:38 +0530] "GET /hello HTTP/1.1" 200 10 "-" "curl/7.55.1"
 
 # Or, run the service by setting `-e b7a.http.accesslog.path=path/to/file.txt` to log to the specified file.
 $ ballerina run -e b7a.http.accesslog.path=path/to/file.txt http_access_logs.bal
 ballerina: HTTP access log enabled
-ballerina: initiating service(s) in 'http_access_logs.bal'
+Initiating service(s) in 'http_access_logs.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9095

--- a/examples/http-circuit-breaker/http_circuit_breaker.server.out
+++ b/examples/http-circuit-breaker/http_circuit_breaker.server.out
@@ -1,7 +1,7 @@
 #At the command line, navigate to the directory that contains the 
 #`http_circuit_breaker.bal` file and run the `ballerina run` command to start the server.
 $ ballerina run http_circuit_breaker.bal
-ballerina: initiating service(s) in 'http_circuit_breaker.bal'
+Initiating service(s) in 'http_circuit_breaker.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090
 ballerina: started HTTP/WS server connector 0.0.0.0:8080
 2018-04-23 15:35:04,407 INFO  [ballerina.http] - CircuitBreaker failure threshold exceeded. Circuit tripped from CLOSE to OPEN state.

--- a/examples/http-cors/http_cors.server.out
+++ b/examples/http-cors/http_cors.server.out
@@ -1,5 +1,5 @@
 #At the command line, navigate to the directory that contains the 
 #`.bal` file and run the `ballerina run` command to start the service. 
 $ ballerina run http_cors.bal
-ballerina: initiating service(s) in 'http_cors.bal'
+Initiating service(s) in 'http_cors.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9092

--- a/examples/http-data-binding/http_data_binding.server.out
+++ b/examples/http-data-binding/http_data_binding.server.out
@@ -2,5 +2,5 @@
 # and use `$BALLERINA_HOME/bin`.
 $ ballerina run http_data_binding.bal
 #Service deployment:
-ballerina: initiating service(s) in 'http_data_binding.bal'
+Initiating service(s) in 'http_data_binding.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/http-disable-chunking/http_disable_chunking.server.out
+++ b/examples/http-disable-chunking/http_disable_chunking.server.out
@@ -2,6 +2,6 @@
 # and execute the following command from `$BALLERINA_HOME/bin`.
 $ ballerina run http_disable_chunking.bal
 # Service deployment:
-ballerina: initiating service(s) in 'http_disable_chunking.bal'
+Initiating service(s) in 'http_disable_chunking.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9092
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/http-failover/http_failover.server.out
+++ b/examples/http-failover/http_failover.server.out
@@ -1,6 +1,6 @@
 # To run the service, put the code in `http_failover.bal`
 # and execute the following command from `$BALLERINA_HOME/bin`.
 $ ballerina run http_failover.bal
-ballerina: initiating service(s) in 'http_failover.bal'
+Initiating service(s) in 'http_failover.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090
 ballerina: started HTTP/WS server connector 0.0.0.0:8080

--- a/examples/http-filters/http_filters.server.out
+++ b/examples/http-filters/http_filters.server.out
@@ -5,7 +5,7 @@ $ ballerina run http_filters.bal
 # To start the service, put the code in "http_filters.bal"
 # and use "ballerina run" command.
 $ ballerina run http_filters.bal
-ballerina: initiating service(s) in 'http_filters.bal'
+Initiating service(s) in 'http_filters.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 
 # To build a compiled program file, we can use the

--- a/examples/http-forwarded-extension/http_forwarded_extension.server.out
+++ b/examples/http-forwarded-extension/http_forwarded_extension.server.out
@@ -2,5 +2,5 @@
 # and use `$BALLERINA_HOME/bin`.
 $ ballerina run http_forwarded_extension.bal
 #Service deployment:
-ballerina: initiating service(s) in 'http_forwarded_extension.bal'
+Initiating service(s) in 'http_forwarded_extension.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/http-load-balancer/http_load_balancer.server.out
+++ b/examples/http-load-balancer/http_load_balancer.server.out
@@ -2,5 +2,5 @@
 # and execute the following command from `$BALLERINA_HOME/bin`.
 $ ballerina run http_load_balancer.bal
 # Service deployment:
-ballerina: initiating service(s) in 'http_load_balancer.bal'
+Initiating service(s) in 'http_load_balancer.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/http-retry/http_retry.server.out
+++ b/examples/http-retry/http_retry.server.out
@@ -1,7 +1,7 @@
 #At the command line, navigate to the directory that contains the 
 #`http_retry.bal` file and run the `ballerina run` command to start the server.
 $ ballerina run http_retry.bal.bal
-ballerina: initiating service(s) in 'http_retry.bal'
+Initiating service(s) in 'http_retry.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:8080
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 2018-04-23 15:31:07,872 INFO  [] - Request received from the client to delayed service.

--- a/examples/http-timeout/http_timeout.server.out
+++ b/examples/http-timeout/http_timeout.server.out
@@ -1,7 +1,7 @@
 #At the command line, navigate to the directory that contains the
 #`http_timeout.bal` file and run the `ballerina run` command to start the server.
 ballerina run http_timeout.bal
-ballerina: initiating service(s) in 'http_timeout.bal'
+Initiating service(s) in 'http_timeout.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:8080
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 2018-08-10 19:56:26,462 ERROR [] - Error sending response from mock service : {message:"Connection between remote client and host is closed", cause:null}

--- a/examples/http-trace-logs/http_trace_logs.server.out
+++ b/examples/http-trace-logs/http_trace_logs.server.out
@@ -4,7 +4,7 @@
 # `.bal` file and run the `ballerina run` command with this runtime argument. 
 $ ballerina run -e b7a.http.tracelog.console=true http_trace_logs.bal
 ballerina: HTTP trace log enabled
-ballerina: initiating service(s) in 'http_trace_logs.bal'
+Initiating service(s) in 'http_trace_logs.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090
 # In the logs, `http.downstream` refers to the HTTP traffic that flows between the client and Ballerina, 
 # while `http.upstream` refers to the HTTP traffic that flows between Ballerina and the backend.

--- a/examples/https-listener/https_listener.server.out
+++ b/examples/https-listener/https_listener.server.out
@@ -1,5 +1,5 @@
 #At the command line, navigate to the directory that contains the 
 #`.bal` file and run the `ballerina run` command to start the listener.
 $ ballerina run https_listener.bal
-ballerina: initiating service(s) in 'https_listener.bal'
+Initiating service(s) in 'https_listener.bal'
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:9095

--- a/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.out
+++ b/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.out
@@ -5,5 +5,5 @@ $ broker
 # 'jms_durable_topic_message_subscriber.bal' file and issue the 'ballerina run' command.
 $ ballerina run jms_durable_topic_message_subscriber.bal
 # The JMS subscriber runs as a Ballerina service and listens to the subscribed topic.
-ballerina: initiating service(s) in 'jms_durable_topic_message_subscriber.bal'
+Initiating service(s) in 'jms_durable_topic_message_subscriber.bal'
 2018-06-14 15:03:15,634 INFO  [ballerina/jms] - Durable subscriber created for topic BallerinaTopic

--- a/examples/jms-headers-and-properties/jms_headers_and_properties.out
+++ b/examples/jms-headers-and-properties/jms_headers_and_properties.out
@@ -4,5 +4,5 @@ $ broker
 # At the command line, navigate to the directory that contains the
 # `jms_headers_and_properties.bal` file and run the `ballerina run` command.
 $ ballerina run jms_headers_and_properties.bal
-ballerina: initiating service(s) in 'jms_headers_and_properties.bal'
+Initiating service(s) in 'jms_headers_and_properties.bal'
 2018-06-14 15:14:30,739 INFO  [ballerina/jms] - Message receiver created for queue MyQueue

--- a/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.out
+++ b/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.out
@@ -6,5 +6,5 @@ $ broker
 $ ballerina run jms_queue_message_receiver_with_client_acknowledgment.bal
 
 # The JMS queue receiver runs as a Ballerina service and listens to the subscribed queue.
-ballerina: initiating service(s) in 'jms_queue_message_receiver_with_client_acknowledgment.bal'
+Initiating service(s) in 'jms_queue_message_receiver_with_client_acknowledgment.bal'
 2018-06-14 15:22:13,061 INFO  [ballerina/jms] - Message receiver created for queue MyQueue

--- a/examples/jms-queue-message-receiver/jms_queue_message_receiver.out
+++ b/examples/jms-queue-message-receiver/jms_queue_message_receiver.out
@@ -6,5 +6,5 @@ $ broker
 $ ballerina run jms_queue_message_receiver.bal
 # The JMS subscriber runs as a Ballerina service and listens to the subscribed queue
 # or topic.
-ballerina: initiating service(s) in 'jms_queue_message_receiver.bal'
+Initiating service(s) in 'jms_queue_message_receiver.bal'
 2018-06-14 15:20:04,750 INFO  [ballerina/jms] - Message receiver created for queue MyQueue

--- a/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.out
+++ b/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.out
@@ -5,5 +5,5 @@ $ broker
 # 'ballerina run' command.
 $ ballerina run jms_simple_durable_topic_message_subscriber.bal
 #The JMS subscriber runs as a Ballerina service and listens to the subscribed topic.
-ballerina: initiating service(s) in 'jms_simple_durable_topic_message_subscriber.bal'
+Initiating service(s) in 'jms_simple_durable_topic_message_subscriber.bal'
 2018-06-14 15:23:51,825 INFO  [ballerina/jms] - Durable subscriber created for topic BallerinaTopic

--- a/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.out
+++ b/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.out
@@ -6,5 +6,5 @@ $ broker
 $ ballerina run jms_simple_queue_message_receiver.bal
 # The JMS subscriber runs as a Ballerina service and listens to the subscribed queue
 # or topic.
-ballerina: initiating service(s) in 'jms_simple_queue_message_receiver.bal'
+Initiating service(s) in 'jms_simple_queue_message_receiver.bal'
 2018-06-14 15:26:55,895 INFO  [ballerina/jms] - Message receiver created for queue MyQueue

--- a/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.out
+++ b/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.out
@@ -5,5 +5,5 @@ $ broker
 # 'jms_simple_topic_message_subscriber.bal' file and issue the 'ballerina run' command.
 $ ballerina run jms_simple_topic_message_subscriber.bal
 # The JMS subscriber runs as a Ballerina service and listens to the subscribed topic.
-ballerina: initiating service(s) in 'jms_simple_topic_message_subscriber.bal'
+Initiating service(s) in 'jms_simple_topic_message_subscriber.bal'
 2018-06-14 15:29:50,366 INFO  [ballerina/jms] - Subscriber created for topic BallerinaTopic

--- a/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.out
+++ b/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.out
@@ -5,5 +5,5 @@ $ broker
 # 'ballerina run' command.
 $ ballerina run jms_topic_message_subscriber.bal
 #The JMS subscriber runs as a Ballerina service and listens to the subscribed topic.
-ballerina: initiating service(s) in 'jms_topic_message_subscriber.bal'
+Initiating service(s) in 'jms_topic_message_subscriber.bal'
 2018-06-14 15:36:38,231 INFO  [ballerina/jms] - Subscriber created for topic BallerinaTopic

--- a/examples/join-multiple-streams/join_multiple_streams.out
+++ b/examples/join-multiple-streams/join_multiple_streams.out
@@ -1,7 +1,7 @@
 # At the command line, navigate to the directory that contains the
 # `join_multiple_streams.bal` file and run the `ballerina run` command.
 $ ballerina run join_multiple_streams.bal
-ballerina: initiating service(s) in 'join_multiple_streams.bal'
+Initiating service(s) in 'join_multiple_streams.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 
 # Run the following cURL request. 

--- a/examples/mb-simple-durable-topic-message-subscriber/mb_simple_durable_topic_message_subscriber.out
+++ b/examples/mb-simple-durable-topic-message-subscriber/mb_simple_durable_topic_message_subscriber.out
@@ -4,5 +4,5 @@ $ broker
 # At the command line, navigate to the directory that contains the
 # `.bal` file and run the `ballerina run` command.
 $ ballerina run mb_simple_durable_topic_message_subscriber.bal
-ballerina: initiating service(s) in 'mb_simple_durable_topic_message_subscriber.bal'
+Initiating service(s) in 'mb_simple_durable_topic_message_subscriber.bal'
 2018-06-14 11:59:38,567 INFO  [ballerina/jms] - Durable subscriber created for topic BallerinaTopic

--- a/examples/mb-simple-queue-message-receiver/mb_simple_queue_message_receiver.out
+++ b/examples/mb-simple-queue-message-receiver/mb_simple_queue_message_receiver.out
@@ -4,5 +4,5 @@ $ broker
 # At the command line, navigate to the directory that contains the
 # `.bal` file and run the `ballerina run` command.
 $ ballerina run mb_simple_queue_message_receiver.bal
-ballerina: initiating service(s) in 'mb_simple_queue_message_receiver.bal'
+Initiating service(s) in 'mb_simple_queue_message_receiver.bal'
 2018-06-14 12:02:42,966 INFO  [ballerina/jms] - Message receiver created for queue MyQueue

--- a/examples/mb-simple-topic-message-subscriber/mb_simple_topic_message_subscriber.out
+++ b/examples/mb-simple-topic-message-subscriber/mb_simple_topic_message_subscriber.out
@@ -4,5 +4,5 @@ $ broker
 # At the command line, navigate to the directory that contains the
 # `.bal` file and run the `ballerina run` command.
 $ ballerina run mb_simple_topic_message_subscriber.bal
-ballerina: initiating service(s) in 'mb_simple_topic_message_subscriber.bal'
+Initiating service(s) in 'mb_simple_topic_message_subscriber.bal'
 2018-06-14 12:05:00,105 INFO  [ballerina/jms] - Subscriber created for topic BallerinaTopic

--- a/examples/passthrough/passthrough.server.out
+++ b/examples/passthrough/passthrough.server.out
@@ -1,3 +1,3 @@
 $ ballerina run passthrough.bal
-ballerina: initiating service(s) in 'passthrough.bal'
+Initiating service(s) in 'passthrough.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/query-path-matrix-param/query_path_matrix_param.server.out
+++ b/examples/query-path-matrix-param/query_path_matrix_param.server.out
@@ -1,5 +1,5 @@
 # At the command line, navigate to the directory that contains the
 # `.bal` file and run the `ballerina run` command to start the server.
 $ ballerina run query_path_matrix_param.bal
-ballerina: initiating service(s) in '.../query_path_matrix_param.bal'
+Initiating service(s) in '.../query_path_matrix_param.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/restrict-by-media-type/restrict_by_media_type.server.out
+++ b/examples/restrict-by-media-type/restrict_by_media_type.server.out
@@ -2,5 +2,5 @@
 # `.bal` file and run the `ballerina run` command to start the server.
 $ ballerina run restrict_by_media_type.bal
 # Service deployment:
-ballerina: initiating service(s) in 'restrict_by_media_type.bal'
+Initiating service(s) in 'restrict_by_media_type.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/examples/secured-service-with-basic-auth/secured_service_with_basic_auth.server.out
+++ b/examples/secured-service-with-basic-auth/secured_service_with_basic_auth.server.out
@@ -3,7 +3,7 @@
 # Ensure that the `sample-users.toml` file is populated correctly with user
 # information and specify it as the configuration file using the `--config` flag.
 $ ballerina run secured_service_with_basic_auth.bal
-ballerina: initiating service(s) in 'secured_service_with_basic_auth.bal'
+Initiating service(s) in 'secured_service_with_basic_auth.bal'
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:9090
 
 # To build a compiled program file, use the

--- a/examples/secured-service-with-jwt/secured_service_with_jwt.server.out
+++ b/examples/secured-service-with-jwt/secured_service_with_jwt.server.out
@@ -1,7 +1,7 @@
 # Create a file named `secured_service_with_jwt.bal`, copy the code
 # into it, and use the `ballerina run` command to start the service.
 $ ballerina run secured_service_with_jwt.bal
-ballerina: initiating service(s) in 'secured_service_with_jwt.bal'
+Initiating service(s) in 'secured_service_with_jwt.bal'
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:9090
 
 # To build a compiled program file, use the

--- a/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.out
+++ b/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.out
@@ -1,6 +1,6 @@
 #At the command line, navigate to the directory that contains the 
 #`.bal` file and run the `ballerina run` command. 
 $ ballerina run send_jms_message_to_http_endpoint.bal
-ballerina: initiating service(s) in 'send_jms_message_to_http_endpoint.bal'
+Initiating service(s) in 'send_jms_message_to_http_endpoint.bal'
 2018-06-14 15:43:04,283 INFO  [ballerina/jms] - Message receiver created for queue MyQueue
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090

--- a/examples/temporal-aggregations-and-windows/temporal_aggregations_and_windows.out
+++ b/examples/temporal-aggregations-and-windows/temporal_aggregations_and_windows.out
@@ -1,7 +1,7 @@
 # At the command line, navigate to the directory that contains the
 # `temporal_aggregations_and_windows.bal` file and run the `ballerina run` command.
 $ ballerina run temporal_aggregations_and_windows.bal
-ballerina: initiating service(s) in 'temporal_aggregations_and_windows.bal'
+Initiating service(s) in 'temporal_aggregations_and_windows.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090
 
 $ curl -X POST http://localhost:9090/requests -d "{'message' : 'request successfully received'}"

--- a/examples/tracing/tracing.server.out
+++ b/examples/tracing/tracing.server.out
@@ -5,8 +5,8 @@ $ docker run -d -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16
 # `.bal` file and use the `ballerina run` command with `--observe` param.
 $ ballerina run --observe tracing.bal
 ballerina: started publishing tracers to Jaeger on localhost:5775
-ballerina: initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
+Initiating service(s) in 'ballerina-home/lib/balx/prometheus/reporter.balx'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9797
 ballerina: started Prometheus HTTP endpoint 0.0.0.0:9797
-ballerina: initiating service(s) in 'tracing.bal'
+Initiating service(s) in 'tracing.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:9234

--- a/examples/transactions-distributed/initiator.out
+++ b/examples/transactions-distributed/initiator.out
@@ -1,6 +1,6 @@
 #At the command line, navigate to the directory that contains the 
 #`.bal` file and run the `ballerina run` command to start the `initiator` service.  
 $ ballerina run iniator.bal
-ballerina: initiating service(s) in 'initiator'
+Initiating service(s) in 'initiator'
 ballerina: started HTTP/WS endpoint localhost:8080
 ballerina: started HTTP/WS endpoint 10.100.1.182:53871

--- a/examples/transactions-distributed/participant.out
+++ b/examples/transactions-distributed/participant.out
@@ -2,7 +2,7 @@
 #'.bal' file and issue the 'ballerina run' command.
 #Run this command to start the `participant` service.
 $ ballerina run participant.bal
-ballerina: initiating service(s) in 'participant'
+Initiating service(s) in 'participant'
 ballerina: started HTTP/WS endpoint 10.100.1.182:54774
 ballerina: started HTTP/WS endpoint localhost:8889
 

--- a/examples/websub-hub-client-sample/subscriber_service.out
+++ b/examples/websub-hub-client-sample/subscriber_service.out
@@ -1,6 +1,6 @@
 # Note how the update published after unsubscription is not received by the subscriber service.
 $ ballerina run subscriber_service.bal
-ballerina: initiating service(s) in 'subscriber_service.bal'
+Initiating service(s) in 'subscriber_service.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:8181
 ballerina: Intent Verification agreed - Mode [subscribe], Topic [http://websubpubtopic.com], Lease Seconds [86400]
 2018-04-26 22:40:47,310 INFO  [] - WebSub Notification Received: {"action":"publish", "mode":"internal-hub"}

--- a/examples/websub-internal-hub-sample/subscriber.out
+++ b/examples/websub-internal-hub-sample/subscriber.out
@@ -1,5 +1,5 @@
 $ ballerina run subscriber.bal
-ballerina: initiating service(s) in 'subscriber.bal'
+Initiating service(s) in 'subscriber.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:8181
 2018-04-26 21:43:17,452 INFO  [ballerina/websub] - Subscription Request successful at Hub[https://localhost:9191/websub/hub], for Topic[http://websubpubtopic.com], with Callback [http://localhost:8181/websub]
 2018-04-26 21:43:17,555 INFO  [ballerina/websub] - Intent Verification agreed - Mode [subscribe], Topic [http://websubpubtopic.com], Lease Seconds [36000]

--- a/examples/websub-remote-hub-sample/subscriber.out
+++ b/examples/websub-remote-hub-sample/subscriber.out
@@ -1,5 +1,5 @@
 $ ballerina run subscriber.bal
-ballerina: initiating service(s) in 'subscriber.bal'
+Initiating service(s) in 'subscriber.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:8181
 2018-04-26 22:20:45,790 INFO  [ballerina/websub] - Subscription Request successful at Hub[https://localhost:9191/websub/hub], for Topic[http://websubpubtopic.com], with Callback [http://localhost:8181/websub]
 2018-04-26 22:20:45,887 INFO  [ballerina/websub] - Intent Verification agreed - Mode [subscribe], Topic [http://websubpubtopic.com], Lease Seconds [36000]

--- a/examples/websub-service-integration-sample/order_mgmt_service.server.out
+++ b/examples/websub-service-integration-sample/order_mgmt_service.server.out
@@ -1,6 +1,6 @@
 # This sample requires starting up the Subscriber Service after the Publisher Service
 $ ballerina run order_mgmt_service.server.bal
-ballerina: initiating service(s) in 'websub_service_integration_sample.bal'
+Initiating service(s) in 'websub_service_integration_sample.bal'
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:9191
 ballerina: Default Ballerina WebSub Hub started up at https://localhost:9191/websub/hub
 ballerina: started HTTP/WS endpoint 0.0.0.0:9090

--- a/examples/websub-service-integration-sample/subscriber.out
+++ b/examples/websub-service-integration-sample/subscriber.out
@@ -1,5 +1,5 @@
 $ ballerina run subscriber.bal
-ballerina: initiating service(s) in 'subscriber.bal'
+Initiating service(s) in 'subscriber.bal'
 ballerina: started HTTP/WS endpoint 0.0.0.0:8181
 2018-08-08 10:56:50,048 INFO  [ballerina/websub] - Subscription Request successful at Hub[https://localhost:9191/websub/hub], for Topic[http://localhost:9090/ordermgt/ordertopic], with Callback [http://localhost:8181/ordereventsubscriber]
 ballerina: Intent Verification agreed - Mode [subscribe], Topic [http://localhost:9090/ordermgt/ordertopic], Lease Seconds [3600]


### PR DESCRIPTION
## Purpose
With https://github.com/ballerina-platform/ballerina-lang/pull/10362, `ballerina: ` is only expected to be used with CLI error messages.

Thus the following log
```
ballerina: initiating service(s) in '<FILE_OR_PACKAGE_NAME>'
```
is changed to
```
Initiating service(s) in '<FILE_OR_PACKAGE_NAME>'
```