### PR TITLE
Remove sealed word from array example

### DIFF
--- a/examples/arrays/arrays.bal
+++ b/examples/arrays/arrays.bal
@@ -38,7 +38,7 @@ public function main() {
     io:println(lengthof f);
 
     // To infer the size of the array from the array literal, following syntax is used.
-    // This will fix the length of the array to a size of four.
+    // This will fix the length of the array to four.
     int[!...] g = [1, 2, 3, 4];
     io:println(lengthof g);
 }

--- a/examples/arrays/arrays.bal
+++ b/examples/arrays/arrays.bal
@@ -37,8 +37,8 @@ public function main() {
     int[5] f;
     io:println(lengthof f);
 
-    // To infer the size of the array from the array literal, following syntax is used.
-    // This will fix the length of the array to four.
+    // To infer the size of the array from the array literal, use the following syntax.
+    // This sets the length of the array to four.
     int[!...] g = [1, 2, 3, 4];
     io:println(lengthof g);
 }

--- a/examples/arrays/arrays.bal
+++ b/examples/arrays/arrays.bal
@@ -29,15 +29,16 @@ public function main() {
     // This prints the first value of the two-dimensional array.
     io:println(iarray[0][0]);
 
-    // This creates a sealed `int` array of length 5.
+    // This creates an `int` array with a fixed length of five.
     int[5] e = [1, 2, 3, 4, 5];
     io:println(lengthof e);
 
-    // This creates a sealed `int` array of length 5 with default value `0` as member values.
+    // This creates an `int` array with a fixed length of five and default value `0` as member values.
     int[5] f;
     io:println(lengthof f);
 
-    // To infer the size of the sealed array from the array literal, following syntax is used.
+    // To infer the size of the array from the array literal, following syntax is used.
+    // This will fix the length of the array to a size of four.
     int[!...] g = [1, 2, 3, 4];
     io:println(lengthof g);
 }

--- a/examples/arrays/arrays.description
+++ b/examples/arrays/arrays.description
@@ -1,3 +1,3 @@
-// Arrays in Ballerina are mutable lists of values of dynamic length where each member of the list is
-// specified with the same type. The implicit initial value of an array is the array with a length of `0`.
-// The length of an array can be fixed by providing the length at the point of declaration.
+// In Ballerina, arrays are mutable lists of values with dynamic length, where each member in the list is
+// of the same type. The implicit initial value of an array is the array with a length of 0.
+// If you want to have a fixed length array, specify the length of the array at the time of declaration.

--- a/examples/arrays/arrays.description
+++ b/examples/arrays/arrays.description
@@ -1,6 +1,3 @@
 // Arrays in Ballerina are mutable lists of values of dynamic length where each member of the list is
 // specified with the same type. The implicit initial value of an array is the array with a length of `0`.
-//
-// A Sealed Array in Ballerina is a list of values of fixed length, where each member value of the list is
-// specified with the same type.
-// The size of the sealed array should be specified at the point of declaration and can not be changed afterwards.
+// The length of an array can be fixed by providing the length at the point of declaration.


### PR DESCRIPTION
The term sealed is removed from the example since it is not used in the language spec