### PR TITLE
Re-organize service authentication examples

### DIFF
--- a/examples/secured-service-with-basic-auth/sample-users.toml
+++ b/examples/secured-service-with-basic-auth/sample-users.toml
@@ -1,0 +1,9 @@
+["b7a.users"]
+
+["b7a.users.generalUser1"]
+password="password"
+scopes="scope1"
+
+["b7a.users.generalUser2"]
+password="password"
+scopes="scope2"

--- a/examples/secured-service-with-basic-auth/secured_service_with_basic_auth.client.out
+++ b/examples/secured-service-with-basic-auth/secured_service_with_basic_auth.client.out
@@ -1,5 +1,9 @@
-// Invoke the service using this cURL command. 
-// Note that it is required to provide the correct basic authentication header
-// with the cURL command.
-$ curl -vk -u <username>:<password> https://localhost:9090/hello/sayHello
+# Since resource configuration has overridden the required scopes to denote that
+# `scope2` is required to invoke `sayHello` resource, the invocation will fail
+# authorization.
+$ curl -k -u generalUser1:password https://localhost:9090/hello/sayHello
+Authorization failure
+
+# Since `generalUser2` has `scope2` the invocation will succeeded.
+$ curl -k -u generalUser2:password https://localhost:9090/hello/sayHello
 Hello, World!

--- a/examples/secured-service-with-basic-auth/secured_service_with_basic_auth.server.out
+++ b/examples/secured-service-with-basic-auth/secured_service_with_basic_auth.server.out
@@ -1,14 +1,18 @@
-# Create a file named `secured_service_with_basic_auth.bal`, copy the code
-# into it, and use the `ballerina run` command to start the service.
-# Ensure that the `sample-users.toml` file is populated correctly with user
-# information and specify it as the configuration file using the `--config` flag.
-$ ballerina run secured_service_with_basic_auth.bal
+# At the command line, navigate to the directory that contains the
+# `.bal` file. Ensure that the `sample-users.toml` file is populated correctly
+# with the user information. If required, user passwords can be encrypted using
+# the `ballerina encrypt` configuration encryption command.
+$ echo '["b7a.users"]
+["b7a.users.generalUser1"]
+password="password"
+scopes="scope1"
+["b7a.users.generalUser2"]
+password="password"
+scopes="scope2"
+' > sample-users.toml
+
+# Specify the configuration file name using the `--config` flag and run the
+# program using `ballerina run` command.
+$ ballerina run --config sample-users.toml secured_service_with_basic_auth.bal
 Initiating service(s) in 'secured_service_with_basic_auth.bal'
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:9090
-
-# To build a compiled program file, use the
-# `ballerina build` command followed by
-# the service package name.
-$ ballerina build secured_service_with_basic_auth.bal
-$ ls
-secured_service_with_basic_auth.balx	secured_service_with_basic_auth.bal

--- a/examples/secured-service-with-jwt/secured_service_with_jwt.server.out
+++ b/examples/secured-service-with-jwt/secured_service_with_jwt.server.out
@@ -1,12 +1,5 @@
-# Create a file named `secured_service_with_jwt.bal`, copy the code
-# into it, and use the `ballerina run` command to start the service.
+# At the command line, navigate to the directory that contains the
+# `.bal` file and run the `ballerina run` command.
 $ ballerina run secured_service_with_jwt.bal
 Initiating service(s) in 'secured_service_with_jwt.bal'
 ballerina: started HTTPS/WSS endpoint 0.0.0.0:9090
-
-# To build a compiled program file, use the
-# `ballerina build` command followed by
-# the service package name.
-$ ballerina build secured_service_with_jwt.bal
-$ ls
-secured_service_with_jwt.balx	secured_service_with_jwt.bal


### PR DESCRIPTION
## Purpose
Ballerina examples `secured-service-with-basic-auth` talk about configuration based user-store. However the sample user store file (toml) was not provided. With this PR relevant instructions as well as the toml file was added and irrelevant comment about the `ballerina build` command was removed. 