### PR TITLE
Fix channels correlation example error

### DIFF
--- a/examples/channels-correlation/channels_correlation.bal
+++ b/examples/channels-correlation/channels_correlation.bal
@@ -1,4 +1,5 @@
 import ballerina/http;
+import ballerina/log;
 
 //Defines a channel with json constrained type.
 channel<json> jsonChannel;


### PR DESCRIPTION
## Purpose
There is a compilation error in channels_correlation example. This was due to missing log library.

